### PR TITLE
Enforce validation of input array depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ results = spiralizer.read
 
 ### Invalid Inputs
 
-The `#read` method will throw one of two exceptions if your data is invalid.
+The `#read` method will throw one of the following exceptions if your data is invalid.
 
 #### MatrixSpiralizer::InvalidInputError
 
@@ -87,6 +87,18 @@ a different length than its predecessor.
   ['A', 'Z', 'R'],
   ['F', 'K', 'L', 'M'],
   ['A', 'Z', 'N']
+]
+```
+
+#### MatrixSpiralizer::ProhibitedArrayDepth
+
+This error is used when your input consists of more than 1 layer of array nesting. For example, the following is invalid:
+
+```ruby
+[
+  ['A', 'B', 'C'],
+  ['D', ['E'], 'F'],
+  ['H', 'I', 'J']
 ]
 ```
 

--- a/lib/matrix_spiralizer.rb
+++ b/lib/matrix_spiralizer.rb
@@ -1,6 +1,7 @@
 class MatrixSpiralizer
   class InvalidInputError < StandardError; end
   class InconsistentLengthError < StandardError; end
+  class ProhibitedArrayDepth < StandardError; end
 
   VALID_CHARACTER_REGEX = /[A-Z]/
 
@@ -21,10 +22,17 @@ class MatrixSpiralizer
 
   def validate_matrix
     validate_length_consistency
+    validate_array_depth
     validate_characters
   end
 
   private
+
+  def validate_array_depth
+    return true unless matrix.flatten(1).any? { |val| val.is_a?(Array) }
+
+    raise ProhibitedArrayDepth, 'You may not nest arrays more than a single layer.'
+  end
 
   def validate_length_consistency
     first_row_length = matrix.first.size

--- a/spec/matrix_spiralizer_spec.rb
+++ b/spec/matrix_spiralizer_spec.rb
@@ -32,6 +32,20 @@ describe MatrixSpiralizer do
   describe '#validate_matrix' do
     subject { spiralizer.validate_matrix }
 
+    context 'when nesting arrays more than 2-levels deep' do
+      let(:spiralizer) do
+        MatrixSpiralizer.new([
+          %w(A B C),
+          ['D', ['E'], 'F'],
+          %w(H I J)
+        ])
+      end
+
+      it 'raises an exception' do
+        expect { subject }.to raise_error(MatrixSpiralizer::ProhibitedArrayDepth)
+      end
+    end
+
     context 'given an input with varying inner-array lengths' do
       let(:spiralizer) do
         MatrixSpiralizer.new([


### PR DESCRIPTION
Input cannot be considered a valid matrix when the array nesting is
deeper than a single layer. This introduces a new exception to be thrown
when it is determined that the nesting depth is too deep.